### PR TITLE
Include filesize when creating file, and use correct dbpedia url

### DIFF
--- a/lib/delta-file.js
+++ b/lib/delta-file.js
@@ -26,8 +26,10 @@ export default class DeltaFile {
       const filepath = `${dir}/${filename}`;
       await fs.ensureDir(dir);
       await fs.writeJSON(filepath, this.delta);
+      const stats = fs.statSync(filepath);
+      const fileSizeInBytes = stats.size;
       console.log(`Delta has been written to file.`);
-      await this.writeFileToStore(filename, filepath);
+      await this.writeFileToStore(filename, fileSizeInBytes);
       console.log('File is persisted in store and can be consumed now.');
     } catch (e) {
       console.log(e);
@@ -76,7 +78,7 @@ export default class DeltaFile {
   /**
    * @private
    */
-  async writeFileToStore(filename) {
+  async writeFileToStore(filename, filesize) {
     const virtualFileUuid = uuid();
     const virtualFileUri = `http://data.lblod.info/files/${virtualFileUuid}`;
     const nowLiteral = sparqlEscapeDateTime(moment());
@@ -87,7 +89,7 @@ export default class DeltaFile {
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX dbpedia: <http://dbpedia.org/resource/>
+    PREFIX dbpedia: <http://dbpedia.org/ontology/>
     PREFIX dct: <http://purl.org/dc/terms/>
 
     INSERT DATA {
@@ -95,6 +97,7 @@ export default class DeltaFile {
         <${virtualFileUri}> a nfo:FileDataObject ;
           mu:uuid "${virtualFileUuid}" ;
           nfo:fileName "${filename}" ;
+          nfo:fileSize "${filesize}" ;
           dct:format "application/json" ;
           dbpedia:fileExtension "json" ;
           dct:created ${nowLiteral} ;
@@ -104,6 +107,7 @@ export default class DeltaFile {
           mu:uuid "${physicalFileUuid}" ;
           nie:dataSource <${virtualFileUri}> ;
           nfo:fileName "${filename}" ;
+          nfo:fileSize "${filesize}" ;
           dct:format "application/json" ;
           dbpedia:fileExtension "json" ;
           dct:created ${nowLiteral} ;


### PR DESCRIPTION
Was having some trouble fetching the delta file information cause the consumer service expects the filesize property to be set.
I hijacked the second argument of writeFileToStore for this as it wasnt being used anyway

Also, the consumer uses dbpedia.org/ontology/ instead of dbpedia.org/resource/ as was used in the producer. From what I can tell the former seems more correct so I adjusted the producer. 